### PR TITLE
Fix images and labels on team page

### DIFF
--- a/team.html
+++ b/team.html
@@ -367,19 +367,7 @@
         }
 
         .team-card::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 4px;
-            background: linear-gradient(90deg, #d4af37, #2c5530);
-            opacity: 0;
-            transition: opacity 0.3s;
-        }
-
-        .team-card:hover::before {
-            opacity: 1;
+            content: none;
         }
 
         .team-card:hover {
@@ -396,7 +384,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background: linear-gradient(135deg, #2c5530, #4a7c4a);
+            background: none;
             color: white;
             font-size: 2.5rem;
             font-weight: bold;
@@ -1063,7 +1051,7 @@
                 <div class="team-grid">
                     <div class="team-card leadership-card">
                         <div class="team-photo">
-                            <img src="images/members/Rasmus_Wolthers.png" alt="Rasmus Wolthers" onerror="this.style.display='none'; this.parentElement.innerHTML='RW';">
+                            <img src="images/members/rasmus_wolthers.png" alt="Rasmus Wolthers" onerror="this.style.display='none'; this.parentElement.innerHTML='RW';">
                         </div>
                         <div class="team-name">Rasmus Wolthers</div>
                         <div class="team-position" data-lang-key="ceoTitle">Partner &amp; Chief Executive Officer</div>
@@ -1111,7 +1099,7 @@
                             <img src="images/members/Svenn_Wolthers.png" alt="Svenn Wolthers" onerror="this.style.display='none'; this.parentElement.innerHTML='SW';">
                         </div>
                         <div class="team-name">Svenn Wolthers</div>
-                        <div class="team-position" data-lang-key="labsMarketing">Partner, Labs &amp; Marketing</div>
+                        <div class="team-position" data-lang-key="labsMarketing">Partner, Labs &amp; Client Relations</div>
                         <div class="team-specialty trader" data-lang-key="generation3rdSimple">3rd Generation</div>
                         <div class="team-description" data-lang-key="svennDescription">Oversees Guatemala and Colombia labs, supports marketing across Latin America.</div>
                     </div>
@@ -1157,7 +1145,7 @@
                         </div>
                         <div class="team-name">Petter Anderson</div>
                         <div class="team-position" data-lang-key="qualitySupportAnalyst">Quality Support Analyst</div>
-                        <div class="team-specialty quality">Quality Expert</div>
+                        <div class="team-specialty quality">Quality Control</div>
                         <div class="team-description" data-lang-key="petterDescription">Quality analyst supporting comprehensive quality control processes.</div>
                     </div>
                     <div class="team-card">
@@ -1166,7 +1154,7 @@
                         </div>
                         <div class="team-name">Victor Di Paula</div>
                         <div class="team-position" data-lang-key="qualitySupportAnalyst">Quality Support Analyst</div>
-                        <div class="team-specialty quality">Quality Expert</div>
+                        <div class="team-specialty quality">Quality Control</div>
                         <div class="team-description" data-lang-key="victorDescription">Quality analyst ensuring consistent standards for coffee evaluations.</div>
                     </div>
                     <div class="team-card">


### PR DESCRIPTION
## Summary
- remove decorative gradient border on team cards
- remove green gradient from team photos
- fix Rasmus Wolthers image path
- update Svenn's title to "Partner, Labs & Client Relations"
- switch Petter Anderson and Victor Di Paula "Quality Expert" labels to "Quality Control"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be77baf80833386903004908910d5