### PR TITLE
Refactor pages to use bootstrap modules and theme manager

### DIFF
--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -1,0 +1,4 @@
+// TODO: Move authentication logic from main.js into this module
+export function initAuth() {
+  console.warn('initAuth is a placeholder');
+}

--- a/js/modules/companies.js
+++ b/js/modules/companies.js
@@ -1,0 +1,4 @@
+// TODO: Move company linking logic into this module
+export function initCompanies() {
+  console.warn('initCompanies is a placeholder');
+}

--- a/js/modules/theme.js
+++ b/js/modules/theme.js
@@ -1,0 +1,23 @@
+export function applyTheme() {
+  let theme = localStorage.getItem('theme');
+  if (!theme) {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', theme);
+  document.body.setAttribute('data-theme', theme);
+  document.querySelectorAll('style[data-prefers-dark]').forEach(el => {
+    el.disabled = theme === 'light';
+  });
+}
+
+export function switchTheme() {
+  const current = document.documentElement.getAttribute('data-theme') || 'light';
+  const newTheme = current === 'light' ? 'dark' : 'light';
+  localStorage.setItem('theme', newTheme);
+  applyTheme();
+}
+
+export function initTheme() {
+  applyTheme();
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', applyTheme);
+}

--- a/js/modules/trips.js
+++ b/js/modules/trips.js
@@ -1,0 +1,4 @@
+// TODO: Move trip management logic from main.js into this module
+export function initTrips() {
+  console.warn('initTrips is a placeholder');
+}

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -1,0 +1,4 @@
+// TODO: Move DOM rendering helpers into this module
+export function initUI() {
+  console.warn('initUI is a placeholder');
+}

--- a/js/modules/users.js
+++ b/js/modules/users.js
@@ -1,0 +1,4 @@
+// TODO: Move user management logic into this module
+export function initUsers() {
+  console.warn('initUsers is a placeholder');
+}

--- a/js/modules/utils.js
+++ b/js/modules/utils.js
@@ -1,0 +1,8 @@
+// TODO: Move utility functions into this module
+export function debounce(fn, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}

--- a/js/modules/vehicles.js
+++ b/js/modules/vehicles.js
@@ -1,0 +1,4 @@
+// TODO: Move vehicle table logic into this module
+export function initVehicles() {
+  console.warn('initVehicles is a placeholder');
+}

--- a/js/pages/accounts.bootstrap.js
+++ b/js/pages/accounts.bootstrap.js
@@ -1,0 +1,4 @@
+import { initTheme } from '../modules/theme.js';
+initTheme();
+
+import('../../trips/js/accounts.js');

--- a/js/pages/admin-vehicles.bootstrap.js
+++ b/js/pages/admin-vehicles.bootstrap.js
@@ -1,0 +1,4 @@
+import { initTheme } from '../modules/theme.js';
+initTheme();
+
+import('../../trips/js/admin-vehicles.js');

--- a/js/pages/index.bootstrap.js
+++ b/js/pages/index.bootstrap.js
@@ -1,0 +1,5 @@
+import { initTheme } from '../modules/theme.js';
+initTheme();
+
+import('../../trips/js/microsoft-auth.js');
+import('../../trips/js/main.js');

--- a/trips/accounts.html
+++ b/trips/accounts.html
@@ -28,19 +28,6 @@
             }
         }
     </style>
-    <script>
-      (function() {
-        let theme = localStorage.getItem('theme');
-        if (!theme) {
-          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-        document.documentElement.setAttribute('data-theme', theme);
-        document.body.setAttribute('data-theme', theme);
-        document.querySelectorAll('style[data-prefers-dark]').forEach(el => {
-          el.disabled = theme === 'light';
-        });
-      })();
-    </script>
 
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/accounts.css">
@@ -263,6 +250,6 @@
         </div>
     </div>
 
-    <script src="assets/js/accounts.js"></script>
+    <script type="module" src="../js/pages/accounts.bootstrap.js"></script>
 </body>
-</html> 
+</html>

--- a/trips/admin-vehicles.html
+++ b/trips/admin-vehicles.html
@@ -381,19 +381,6 @@
             }
         }
     </style>
-    <script>
-      (function() {
-        let theme = localStorage.getItem('theme');
-        if (!theme) {
-          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-        document.documentElement.setAttribute('data-theme', theme);
-        document.body.setAttribute('data-theme', theme);
-        document.querySelectorAll('style[data-prefers-dark]').forEach(el => {
-          el.disabled = theme === 'light';
-        });
-      })();
-    </script>
 </head>
 <body>
     <div class="fleet-container">
@@ -460,6 +447,6 @@
         </table>
     </div>
 
-    <script src="js/admin-vehicles.js"></script>
+    <script type="module" src="../js/pages/admin-vehicles.bootstrap.js"></script>
 </body>
-</html> 
+</html>

--- a/trips/index.html
+++ b/trips/index.html
@@ -726,8 +726,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_io/favicon-16x16.png">
     <link rel="manifest" href="favicon_io/site.webmanifest">
     <link rel="shortcut icon" href="favicon_io/favicon.ico">
-    <!-- Microsoft Authentication -->
-    <script src="js/microsoft-auth.js"></script>
 </head>
 <body>
 
@@ -2828,6 +2826,6 @@ The system will automatically:
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script type="module" src="../js/pages/index.bootstrap.js"></script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- centralize dark mode logic in `js/modules/theme.js`
- add placeholder modules for future refactoring
- create bootstrap loaders for index, accounts and admin vehicles pages
- update HTML pages to load the new bootstraps

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685dba4518708333a45b7e059620d074