### PR TITLE
Fix Mitsui trip itinerary layout

### DIFF
--- a/trips/mitsui-jul/index.html
+++ b/trips/mitsui-jul/index.html
@@ -133,6 +133,8 @@
                 <div class="activity">
                     <div class="activity-time">22:00</div>
                     <div class="activity-description">Overnight at the Ibis Hotel</div>
+                </div>
+            </div>
             <div class="day">
                 <div class="day-header">
                     <div class="day-date">Tuesday, July 22nd, 2025</div>


### PR DESCRIPTION
## Summary
- close Monday block properly so Tuesday displays below

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bb648418c8333ba87c95e6033f8ff