### PR TITLE
Update Mitsui trip itinerary

### DIFF
--- a/trips/mitsui-jul/index.html
+++ b/trips/mitsui-jul/index.html
@@ -148,13 +148,25 @@
                     <div class="activity-time">11:00</div>
                     <div class="activity-description">Visit to <strong>SMC</strong></div>
                 </div>
-                <div class="activity">
+                <div class="activity travel-day">
                     <div class="activity-time">12:00</div>
-                    <div class="activity-description">Lunch</div>
+                    <div class="activity-description">Drive to Alfenas</div>
+                </div>
+                <div class="activity">
+                    <div class="activity-time">13:00</div>
+                    <div class="activity-description">Lunch with Monte Alegre: Mr. Jose Francisco and Mr. Helio Leite</div>
+                </div>
+                <div class="activity supplier-visit">
+                    <div class="activity-time">14:00</div>
+                    <div class="activity-description">Cupping at the farm</div>
+                </div>
+                <div class="activity">
+                    <div class="activity-time">15:00</div>
+                    <div class="activity-description">Brief visit at farm</div>
                 </div>
                 <div class="activity travel-day">
-                    <div class="activity-time">15:00</div>
-                    <div class="activity-description">Return to São Paulo International Airport (midnight flight back to Japan)</div>
+                    <div class="activity-time">16:00</div>
+                    <div class="activity-description">Drive to São Paulo Pullman hotel</div>
                 </div>
             </div>
 
@@ -325,16 +337,34 @@
                     description: 'Visit to SMC'
                 },
                 {
-                    summary: 'Lunch',
+                    summary: 'Drive to Alfenas',
                     start: '20250722T120000',
-                    end: '20250722T150000',
-                    description: 'Lunch'
+                    end: '20250722T130000',
+                    description: 'Drive to Alfenas'
                 },
                 {
-                    summary: 'Return to São Paulo International Airport',
+                    summary: 'Lunch with Monte Alegre',
+                    start: '20250722T130000',
+                    end: '20250722T140000',
+                    description: 'Lunch with Monte Alegre: Mr. Jose Francisco and Mr. Helio Leite'
+                },
+                {
+                    summary: 'Cupping at the farm',
+                    start: '20250722T140000',
+                    end: '20250722T150000',
+                    description: 'Cupping at the farm'
+                },
+                {
+                    summary: 'Brief visit at farm',
                     start: '20250722T150000',
-                    end: '20250722T180000',
-                    description: 'Return to São Paulo International Airport (midnight flight back to Japan)'
+                    end: '20250722T160000',
+                    description: 'Brief visit at farm'
+                },
+                {
+                    summary: 'Drive to São Paulo Pullman hotel',
+                    start: '20250722T160000',
+                    end: '20250722T190000',
+                    description: 'Drive to São Paulo Pullman hotel'
                 }
             ]
         };
@@ -472,16 +502,34 @@
                 description: 'Visit to SMC'
             },
             {
-                summary: 'Lunch',
+                summary: 'Drive to Alfenas',
                 start: '20250722T120000',
-                end: '20250722T150000',
-                description: 'Lunch'
+                end: '20250722T130000',
+                description: 'Drive to Alfenas'
             },
             {
-                summary: 'Return to São Paulo International Airport',
+                summary: 'Lunch with Monte Alegre',
+                start: '20250722T130000',
+                end: '20250722T140000',
+                description: 'Lunch with Monte Alegre: Mr. Jose Francisco and Mr. Helio Leite'
+            },
+            {
+                summary: 'Cupping at the farm',
+                start: '20250722T140000',
+                end: '20250722T150000',
+                description: 'Cupping at the farm'
+            },
+            {
+                summary: 'Brief visit at farm',
                 start: '20250722T150000',
-                end: '20250722T180000',
-                description: 'Return to São Paulo International Airport (midnight flight back to Japan)'
+                end: '20250722T160000',
+                description: 'Brief visit at farm'
+            },
+            {
+                summary: 'Drive to São Paulo Pullman hotel',
+                start: '20250722T160000',
+                end: '20250722T190000',
+                description: 'Drive to São Paulo Pullman hotel'
             }
         ];
     </script>


### PR DESCRIPTION
## Summary
- modify Tuesday schedule in `mitsui-jul` itinerary
- update calendar data for the new Tuesday activities

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d546eccf88333822aedf95d48d010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Tuesday, July 22nd, 2025 itinerary with detailed activities, including drives, lunch, cupping, and farm visit.
  
* **Enhancements**
  * Improved daily schedule display with clearer event times and descriptions.
  * Updated event styling for travel and supplier visits.

* **Removals**
  * Removed the "Return to São Paulo International Airport" event, replaced with new travel and hotel arrival sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->